### PR TITLE
a few fixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1012,7 +1012,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     if (pfMissingInputs)
         *pfMissingInputs = false;
 
-    int64_t maxBlockSize = Params().GetConsensus().MaxBlockSize(GetAdjustedTime(), sizeForkTime.load());
+    uint64_t maxBlockSize = Params().GetConsensus().MaxBlockSize(GetAdjustedTime(), sizeForkTime.load());
 
     if (!CheckTransaction(tx, state, maxBlockSize))
         return error("AcceptToMemoryPool: CheckTransaction failed");
@@ -1162,7 +1162,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         }
         else if(poolBytes < maxBlockSize * MAX_BLOCK_SIZE_MULTIPLYER){
             // Gradually choke off what is considered a free transaction
-            feeCutoff = (minRelayTxFee/1000) * (poolBytes-maxBlockSize)/(maxBlockSize * (MAX_BLOCK_SIZE_MULTIPLYER-1));
+            feeCutoff = (minRelayTxFee/1000) * (poolBytes - maxBlockSize) / (maxBlockSize * (MAX_BLOCK_SIZE_MULTIPLYER-1));
 
             // Gradually choke off the nFreeLimit as well but leave at least minFreeLimit
             // So that some free transactions can still get through
@@ -1175,7 +1175,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             nFreeLimit = MIN_LIMIT_FREE_RELAY;
         }
 
-        double satoshiPerByte = nFees/nSize;
+        double satoshiPerByte = ((double)nFees)/nSize;
         LogPrint("mempool",
                  "MempoolBytes:%d  LimitFreeRelay:%d  FeeCutOff:%.4g  FeesSatoshiPerByte:%.4g  TxBytes:%d  TxFees:%d\n",
                   poolBytes,nFreeLimit,feeCutoff,satoshiPerByte, nSize, nFees);

--- a/src/main.h
+++ b/src/main.h
@@ -96,7 +96,7 @@ static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 /** The number of block heights to choke spam transactions over */
 static const unsigned int MAX_BLOCK_SIZE_MULTIPLYER = 3;
 /** The minimum value possible for -limitfreerelay when rate limiting */
-static unsigned int MIN_LIMIT_FREE_RELAY = 2;
+static const unsigned int MIN_LIMIT_FREE_RELAY = 2;
 
 struct BlockHasher
 {


### PR DESCRIPTION
fix integer divide rounding issue, fix compiler signed/unsigned warnings, and defined-but-not-used warning caused by non-const declaration of a const.

possible issue:  You changed this to a character:
static uint8_t nLimitFreeRelay = GetArg("-limitfreerelay", 15);

Tracing this value through the code, it is used as integer and int64... I read a comment that it is 1000s of txns per minute so uint8 would mean 255,000 txns per min.  That's a lot which won't be hit for years I guess but I do not think a few bytes of savings is worth having a latent overflow bug.

WRT the cast to float try this code:
# include <cstdint>
# include <stdio.h>

int main(int argc, char\* argv[])
{
  uint64_t a = 300;
  unsigned int b = 11;
  double c = ((double)a)/b;
  double d = a/b;
  printf("%f %f\n",c,d); 
}

Do you have an easy way to test this patch when the network is not undergoing a spam attack?
